### PR TITLE
Export constructors for HostPreference

### DIFF
--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -4,7 +4,7 @@ module Data.Streaming.Network
     ( -- * Types
       ServerSettings
     , ClientSettings
-    , HostPreference
+    , HostPreference (..)
     , Message (..)
     , AppData
 #if !WINDOWS


### PR DESCRIPTION
This should work, shouldn’t it?

``` haskell
main = runSettings (setPort 3000 $ setHost (Host "::1") $ defaultSettings) application
```
