### PR TITLE
Add full flush support in zlib compression

### DIFF
--- a/Data/Streaming/Zlib.hs
+++ b/Data/Streaming/Zlib.hs
@@ -33,6 +33,7 @@ module Data.Streaming.Zlib
     , feedDeflate
     , finishDeflate
     , flushDeflate
+    , fullFlushDeflate
       -- * Data types
     , WindowBits (..)
     , defaultWindowBits
@@ -281,3 +282,17 @@ finishDeflate (Deflate (fzstr, fbuff)) =
 flushDeflate :: Deflate -> Popper
 flushDeflate (Deflate (fzstr, fbuff)) =
     drain fbuff fzstr Nothing c_call_deflate_flush True
+
+-- | Full flush the deflation buffer. Useful for interactive
+-- applications where previously streamed data may not be
+-- available. Using `fullFlushDeflate` too often can seriously degrade
+-- compression. Internally this passes Z_FULL_FLUSH to the zlib
+-- library.
+--
+-- Like 'flushDeflate', 'fullFlushDeflate' does not signal end of input,
+-- meaning you can feed more uncompressed data afterward.
+--
+-- Since 0.0.3
+fullFlushDeflate :: Deflate -> Popper
+fullFlushDeflate (Deflate (fzstr, fbuff)) =
+    drain fbuff fzstr Nothing c_call_deflate_full_flush True

--- a/Data/Streaming/Zlib/Lowlevel.hs
+++ b/Data/Streaming/Zlib/Lowlevel.hs
@@ -18,6 +18,7 @@ module Data.Streaming.Zlib.Lowlevel
     , c_call_deflate_noflush
     , c_call_deflate_finish
     , c_call_deflate_flush
+    , c_call_deflate_full_flush
     , c_call_deflate_set_dictionary
     , c_call_inflate_set_dictionary
     ) where
@@ -88,6 +89,9 @@ foreign import ccall unsafe "streaming_commons_call_deflate_finish"
 
 foreign import ccall unsafe "streaming_commons_call_deflate_flush"
     c_call_deflate_flush :: ZStream' -> IO CInt
+
+foreign import ccall unsafe "streaming_commons_call_deflate_full_flush"
+    c_call_deflate_full_flush :: ZStream' -> IO CInt
 
 foreign import ccall unsafe "streaming_commons_deflate_set_dictionary"
     c_call_deflate_set_dictionary :: ZStream' -> Ptr CChar -> CUInt -> IO ()

--- a/cbits/zlib-helper.c
+++ b/cbits/zlib-helper.c
@@ -91,6 +91,11 @@ int streaming_commons_call_deflate_flush (z_stream *stream)
 	return deflate(stream, Z_SYNC_FLUSH);
 }
 
+int streaming_commons_call_deflate_full_flush (z_stream *stream)
+{
+	return deflate(stream, Z_FULL_FLUSH);
+}
+
 int streaming_commons_call_deflate_finish (z_stream *stream)
 {
 	return deflate(stream, Z_FINISH);


### PR DESCRIPTION
This patch adds support for `Z_FULL_FLUSH` which is used in some streaming applications. From [zlib documentation](http://www.zlib.net/manual.html):

> All output is flushed as with `Z_SYNC_FLUSH`, and the compression state is reset so that decompression can restart from this point if previous compressed data has been damaged or if random access is desired.
