### PR TITLE
Make getSocket{Family}TCP try all addr candidates

### DIFF
--- a/test/Data/Streaming/NetworkSpec.hs
+++ b/test/Data/Streaming/NetworkSpec.hs
@@ -31,4 +31,4 @@ spec = do
                         | null content = "hello"
                         | otherwise = S8.pack $ take 1000 content
                 withAsync (runTCPServer (serverSettingsTCPSocket socket) server) $ \_ -> do
-                    runTCPClient (clientSettingsTCP port "127.0.0.1") client
+                    runTCPClient (clientSettingsTCP port "localhost") client


### PR DESCRIPTION
Fixes #31.

Some hostnames can resolve to more than one address. A common example is "localhost", that on many (but not all) platforms resolves to `127.0.0.1` (ipv4) and `::1` (ipv6). When one uses `getaddrinfo` in such address, and doesn't specify if one is looking for an ipv4 or ipv6 address (e.g., because one doesn't know and/or don't care and wants to support both), one will get more than one result. The right way of handling this is trying to connect to each of the provided addresses, in order, one by one. However, in the previous implementation, a function such as `runTCPClient` would only attempt to use the first address.

Two things two note:

  - One of the tests in `Data.Streaming.NetworkSpec` was using `runTCPClient` to connect to `"127.0.0.1"`; if one were to change that by "localhost", it would fail on Debian, OS X and others.

  - `bindPortTCP` (via `bindPortGen`) was already trying all given addresses until one succeeded.