### PR TITLE
don't reference deprecated functions

### DIFF
--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -53,7 +53,7 @@ library
                      , blaze-builder >= 0.3 && < 0.5
                      , bytestring
                      , directory
-                     , network
+                     , network >= 2.4.0.0
                      , random
                      , process
                      , stm
@@ -102,7 +102,7 @@ test-suite test
                   , blaze-builder
                   , bytestring
                   , deepseq
-                  , network
+                  , network >= 2.4.0.0
                   , text
                   , zlib
 

--- a/test/Data/Streaming/NetworkSpec.hs
+++ b/test/Data/Streaming/NetworkSpec.hs
@@ -8,7 +8,7 @@ import           Data.Array.Unboxed       (elems)
 import qualified Data.ByteString.Char8    as S8
 import           Data.Char                (toUpper)
 import           Data.Streaming.Network
-import           Network.Socket           (sClose)
+import           Network.Socket           (close)
 import           Test.Hspec
 import           Test.Hspec.QuickCheck
 
@@ -21,7 +21,7 @@ spec = do
     describe "bindRandomPortTCP" $ do
         modifyMaxSuccess (const 5) $ prop "sanity" $ \content -> bracket
             (bindRandomPortTCP "*4")
-            (sClose . snd)
+            (close . snd)
             $ \(port, socket) -> do
                 let server ad = forever $ appRead ad >>= appWrite ad . S8.map toUpper
                     client ad = do


### PR DESCRIPTION
Removes a bunch of GHC warnings related to `NS.bindSocket` and `NS.sClose`