### PR TITLE
Add extended bindPortGenEx function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.17
+
+* Add `bindPortGenEx`
+
 ## 0.1.16
 
 * Add `closeStreamingProcessHandle`

--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -152,6 +152,8 @@ bindPortGen sockettype = bindPortGenEx (defaultSocketOptions sockettype) sockett
 
 -- | Attempt to bind a listening @Socket@ on the given host/port using given
 -- socket options and @SocketType@. If no host is given, will use the first address available.
+--
+-- Since 0.1.17
 bindPortGenEx :: [(NS.SocketOption, Int)] -> SocketType -> Int -> HostPreference -> IO Socket
 bindPortGenEx sockOpts sockettype p s = do
     let hints = NS.defaultHints

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -1,5 +1,5 @@
 name:                streaming-commons
-version:             0.1.16
+version:             0.1.17
 synopsis:            Common lower-level functions needed by various streaming data libraries
 description:         Provides low-dependency functionality commonly needed by various streaming data libraries, such as conduit and pipes.
 homepage:            https://github.com/fpco/streaming-commons


### PR DESCRIPTION
Sometimes I need to setup socket options before bind it and start listen. So I've added extended API for port binding.