### PR TITLE
exposed decompressM and compressM

### DIFF
--- a/test/Data/Streaming/ZlibSpec.hs
+++ b/test/Data/Streaming/ZlibSpec.hs
@@ -18,6 +18,7 @@ import Control.Monad (foldM, forM_, forM)
 import System.IO.Unsafe (unsafePerformIO)
 import qualified Codec.Compression.Zlib.Raw as Raw
 
+
 decompress' :: L.ByteString -> L.ByteString
 decompress' gziped = unsafePerformIO $ do
     inf <- initInflate defaultWindowBits


### PR DESCRIPTION
This PR exposes the two functions `decompress'` and `compress'`defined in test/Data/Streaming/ZlibSpec.hs (without the unsafePerformIO, thus renamed `decompressM`/`compressM`).

Rationale: 

A safe, streaming interface to `zlib` would be extremely useful. I understand `streaming-commons` is meant to be minimal on dependencies, but I'm thinking of writing a high-level wrapper to this library with more idiomatic exception handling based e.g. on `exceptions` (`feedDeflate` would then `throwM` and flush the buffer, rather than returning an error code).



