### PR TITLE
Update getAddrInfo hints

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.19
+
+* Update `getAddrInfo` hints to allow hostnames and portnames [#46](https://github.com/fpco/streaming-commons/issues/46)
+
 ## 0.1.18
 
 * Add `isCompleteInflate`

--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -158,8 +158,7 @@ bindPortGenEx :: [(NS.SocketOption, Int)] -> SocketType -> Int -> HostPreference
 bindPortGenEx sockOpts sockettype p s = do
     let hints = NS.defaultHints
             { NS.addrFlags = [ NS.AI_PASSIVE
-                             , NS.AI_NUMERICSERV
-                             , NS.AI_NUMERICHOST
+                             , NS.AI_ADDRCONFIG
                              ]
             , NS.addrSocketType = sockettype
             }

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -1,5 +1,5 @@
 name:                streaming-commons
-version:             0.1.18
+version:             0.1.19
 synopsis:            Common lower-level functions needed by various streaming data libraries
 description:         Provides low-dependency functionality commonly needed by various streaming data libraries, such as conduit and pipes.
 homepage:            https://github.com/fpco/streaming-commons


### PR DESCRIPTION
The following changes are made, according to Kazu Yamamoto's suggestions:

* Delete `AI_NUMERICHOST` to allow hostnames
* Delete `AI_NUMERICSERV` to allow portnames
* Add `AI_ADDRCONFIG` to ensure to have suitable IP addresses