### PR TITLE
Parentheses for proper rollover when skipping

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.1.0
+
+* Change `bindRandomPortGen` to use binding to port 0
+
 ## 0.2.0
 
 * Drop `blaze-builder` dependency

--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -205,24 +205,10 @@ bindPortGenEx sockOpts sockettype p s = do
 --
 -- Since 0.1.1
 bindRandomPortGen :: SocketType -> HostPreference -> IO (Int, Socket)
-bindRandomPortGen sockettype s =
-    loop (30 :: Int)
-  where
-    loop cnt = do
-        port <- getUnassignedPort
-        esocket <- try $ bindPortGen sockettype port s
-        case esocket :: Either IOException Socket of
-            Left e
-                | cnt <= 1 -> error $ concat
-                    [ "Data.Streaming.Network.bindRandomPortGen: Could not get port. Last attempted: "
-                    , show port
-                    , ". Exception was: "
-                    , show e
-                    ]
-                | otherwise -> do
-                    skipUnassigned 50
-                    loop $! cnt - 1
-            Right socket -> return (port, socket)
+bindRandomPortGen sockettype s = do
+  socket <- bindPortGen sockettype 0 s
+  port <- NS.socketPort socket
+  return (fromIntegral port, socket)
 
 -- | Top 10 Largest IANA unassigned port ranges with no unauthorized uses known
 unassignedPortsList :: [Int]
@@ -262,14 +248,6 @@ getUnassignedPort = do
     go i
         | i > unassignedPortsMax = (succ unassignedPortsMin, unassignedPorts ! unassignedPortsMin)
         | otherwise = (succ i, unassignedPorts ! i)
-
--- | Skip ahead in the unassigned ports list by the given number
-skipUnassigned :: Int -> IO ()
-skipUnassigned i = do
-    !() <- atomicModifyIORef nextUnusedPort $ \j ->
-        let k = (i + j) `mod` unassignedPortsMax
-         in k `seq` (k, ())
-    return ()
 
 -- | Attempt to connect to the given host/port.
 getSocketUDP :: String -> Int -> IO (Socket, AddrInfo)

--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -267,7 +267,7 @@ getUnassignedPort = do
 skipUnassigned :: Int -> IO ()
 skipUnassigned i = do
     !() <- atomicModifyIORef nextUnusedPort $ \j ->
-        let k = i + j `mod` unassignedPortsMax
+        let k = (i + j) `mod` unassignedPortsMax
          in k `seq` (k, ())
     return ()
 

--- a/Data/Streaming/Network.hs
+++ b/Data/Streaming/Network.hs
@@ -200,9 +200,6 @@ bindPortGenEx sockOpts sockettype p s = do
 
 -- | Bind to a random port number. Especially useful for writing network tests.
 --
--- This will attempt 30 different port numbers before giving up and throwing an
--- exception.
---
 -- Since 0.1.1
 bindRandomPortGen :: SocketType -> HostPreference -> IO (Int, Socket)
 bindRandomPortGen sockettype s = do

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -1,5 +1,5 @@
 name:                streaming-commons
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            Common lower-level functions needed by various streaming data libraries
 description:         Provides low-dependency functionality commonly needed by various streaming data libraries, such as conduit and pipes.
 homepage:            https://github.com/fpco/streaming-commons


### PR DESCRIPTION
Current code doesn't result in any errors because `getUnassignedPort` has its own check but the rollover the maximum index will be done not 100% correct