### PR TITLE
Add warning to documentation of ClosedStream type

### DIFF
--- a/Data/Streaming/Process.hs
+++ b/Data/Streaming/Process.hs
@@ -79,6 +79,9 @@ data Inherited = Inherited
 
 -- | Close the stream with the child process.
 --
+-- You usually do not want to use this, as it will leave the corresponding file
+-- descriptor unassigned and hence available for re-use in the child process.
+--
 -- Since 0.1.4
 data ClosedStream = ClosedStream
 


### PR DESCRIPTION
This PR adds a warning to the haddock of the `ClosedStream` datatype about the consequences of immediately closing the handle. The warning is copied from the equivalent binding in the `typed-process` library.