### PR TITLE
Support text-2.0

### DIFF
--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -47,7 +47,7 @@ library
                      , random
                      , process
                      , stm
-                     , text >= 1.2 && < 1.3
+                     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
                      , transformers
                      , zlib
 


### PR DESCRIPTION
Closes #63. Tested with
```yaml
resolver: lts-18.18

extra-deps:
  - hashable-1.4.0.1
  - github: haskell/text
    commit: aee3efe6819fc524bf16daae2936a9bae79748f7
```

UTF8 decoding in `text-2.0` is quite involved and it does not seem right to copy the implementation in full (e. g., it involves 500 Kb of C++ library), so I cheated a bit. I hope it is acceptable, but open to discuss alternatives. 