### PR TITLE
UTF-8 Decoder fails on trailing bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cabal-dev
 *.swp
 .stack-work/
 tarballs/
+dist-newstyle/

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -94,6 +94,8 @@ test-suite test
                   , network >= 2.4.0.0
                   , text
                   , zlib
+    build-tool-depends:
+        hspec-discover:hspec-discover
 
   if flag(use-bytestring-builder)
     build-depends:     bytestring < 0.10.2.0


### PR DESCRIPTION
Fixes #70

Credit to @yoricksijsling who implemented the fix.

I verified that the problem exists - if you uncomment the `modifyMaxSuccess 100000` bit in the tests, you'll see this blow up.