### PR TITLE
Add Data.Streaming.Filesystem version that works with OsPath

### DIFF
--- a/Data/Streaming/Filesystem/OsPath.hs
+++ b/Data/Streaming/Filesystem/OsPath.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DeriveDataTypeable  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Streaming functions for interacting with the filesystem.
+
+module Data.Streaming.Filesystem.OsPath
+  ( DirStream
+  , openDirStream
+  , readDirStream
+  , closeDirStream
+  , FileType (..)
+  , getFileType
+  ) where
+
+import Data.Typeable (Typeable)
+
+import System.Directory.Internal (os)
+
+#if WINDOWS
+
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import System.Directory.OsPath (doesFileExist, doesDirectoryExist)
+import System.OsPath ((</>))
+import System.OsPath.Types (OsPath)
+import System.OsString.Internal.Types (OsString(OsString), getOsString)
+import qualified System.Win32.Types as Win32
+import qualified System.Win32.WindowsString.File as Win32
+
+data DirStream = DirStream !Win32.HANDLE !Win32.FindData !(IORef Bool)
+    deriving Typeable
+
+openDirStream :: OsPath -> IO DirStream
+openDirStream fp = do
+    (h, fdat) <- Win32.findFirstFile $ getOsString $ fp </> os "*"
+    imore <- newIORef True -- always at least two records, "." and ".."
+    return $! DirStream h fdat imore
+
+closeDirStream :: DirStream -> IO ()
+closeDirStream (DirStream h _ _) = Win32.findClose h
+
+readDirStream :: DirStream -> IO (Maybe OsPath)
+readDirStream ds@(DirStream h fdat imore) = do
+    more <- readIORef imore
+    if more
+        then do
+            filename <- Win32.getFindDataFileName fdat
+            Win32.findNextFile h fdat >>= writeIORef imore
+            if filename == getOsString (os ".") || filename == getOsString (os "..")
+                then readDirStream ds
+                else return $ Just $ OsString filename
+        else return Nothing
+
+isSymlink :: OsPath -> IO Bool
+isSymlink _ = return False
+
+getFileType :: OsPath -> IO FileType
+getFileType fp = do
+    isFile <- doesFileExist fp
+    if isFile
+        then return FTFile
+        else do
+            isDir <- doesDirectoryExist fp
+            return $ if isDir then FTDirectory else FTOther
+
+#else
+
+import Control.Exception (try, IOException)
+import System.OsPath.Types (OsPath)
+import System.OsString.Internal.Types (OsString(OsString), getOsString)
+import System.Posix.Directory.PosixPath (DirStream, openDirStream, closeDirStream)
+import qualified System.Posix.Directory.PosixPath as Posix
+import qualified System.Posix.Files.PosixString as PosixF
+
+readDirStream :: DirStream -> IO (Maybe OsPath)
+readDirStream ds = loop
+  where
+    loop = do
+        fp <- Posix.readDirStream ds
+        if fp == mempty
+        then return Nothing
+        else
+            if fp == getOsString (os ".") || fp == getOsString (os "..")
+            then loop
+            else return $ Just $ OsString fp
+
+getFileType :: OsPath -> IO FileType
+getFileType fp = do
+    s <- PosixF.getSymbolicLinkStatus $ getOsString fp
+    case () of
+        ()
+            | PosixF.isRegularFile s -> return FTFile
+            | PosixF.isDirectory s -> return FTDirectory
+            | PosixF.isSymbolicLink s -> do
+                es' <- try $ PosixF.getFileStatus $ getOsString fp
+                case es' of
+                    Left (_ :: IOException) -> return FTOther
+                    Right s'
+                        | PosixF.isRegularFile s' -> return FTFileSym
+                        | PosixF.isDirectory s'   -> return FTDirectorySym
+                        | otherwise               -> return FTOther
+            | otherwise -> return FTOther
+
+#endif
+
+data FileType
+    = FTFile
+    | FTFileSym -- ^ symlink to file
+    | FTDirectory
+    | FTDirectorySym -- ^ symlink to a directory
+    | FTOther
+    deriving (Show, Read, Eq, Ord, Typeable)
+

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -79,6 +79,7 @@ test-suite test
     other-modules:  Data.Streaming.ByteString.BuilderSpec
                     Data.Streaming.FileReadSpec
                     Data.Streaming.FilesystemSpec
+                    Data.Streaming.Filesystem.OsPathSpec
                     Data.Streaming.NetworkSpec
                     Data.Streaming.ProcessSpec
                     Data.Streaming.TextSpec
@@ -92,6 +93,7 @@ test-suite test
                   , async
                   , bytestring
                   , deepseq
+                  , filepath >= 1.4.100
                   , network >= 2.4.0.0
                   , text
                   , zlib

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -30,6 +30,7 @@ library
                        Data.Streaming.ByteString.Builder.Buffer
                        Data.Streaming.FileRead
                        Data.Streaming.Filesystem
+                       Data.Streaming.Filesystem.OsPath
                        Data.Streaming.Network
                        Data.Streaming.Network.Internal
                        Data.Streaming.Process
@@ -42,7 +43,8 @@ library
                      , array
                      , async
                      , bytestring
-                     , directory
+                     , directory >= 1.3.8
+                     , filepath >= 1.4.100
                      , network >= 2.4.0.0
                      , random
                      , process
@@ -57,7 +59,6 @@ library
 
   if os(windows)
     build-depends:     Win32
-                     , filepath
     cpp-options:       -DWINDOWS
     other-modules:     System.Win32File
   else

--- a/test/Data/Streaming/Filesystem/OsPathSpec.hs
+++ b/test/Data/Streaming/Filesystem/OsPathSpec.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE CPP         #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Data.Streaming.Filesystem.OsPathSpec (spec) where
+
+import Control.Exception (bracket)
+import Data.List (sort)
+import Data.Streaming.Filesystem.OsPath
+import System.OsPath (osp)
+import Test.Hspec
+
+#if !WINDOWS
+import System.Posix.Files (removeLink, createSymbolicLink, createNamedPipe)
+import Control.Exception (try, IOException)
+#endif
+
+spec :: Spec
+spec = describe "Data.Streaming.Filesystem" $ do
+    it "dirstream" $ do
+        res <- bracket (openDirStream [osp|test/filesystem|]) closeDirStream
+            $ \ds -> do
+                Just w <- readDirStream ds
+                Just x <- readDirStream ds
+                Just y <- readDirStream ds
+                Just z <- readDirStream ds
+                return $ sort [w, x, y, z]
+        res `shouldBe` [[osp|bar.txt|], [osp|baz.txt|], [osp|bin|], [osp|foo.txt|]]
+    describe "getFileType" $ do
+        it "file" $ getFileType [osp|streaming-commons.cabal|] >>= (`shouldBe` FTFile)
+        it "dir" $ getFileType [osp|Data|] >>= (`shouldBe` FTDirectory)
+#if !WINDOWS
+        it "file sym" $ do
+            _  <- tryIO $ removeLink "tmp"
+            createSymbolicLink "streaming-commons.cabal" "tmp"
+            ft <- getFileType [osp|tmp|]
+            _  <- tryIO $ removeLink "tmp"
+            ft `shouldBe` FTFileSym
+        it "file sym" $ do
+            _  <- tryIO $ removeLink "tmp"
+            createSymbolicLink "Data" "tmp"
+            ft <- getFileType [osp|tmp|]
+            _  <- tryIO $ removeLink "tmp"
+            ft `shouldBe` FTDirectorySym
+        it "other" $ do
+            _ <- tryIO $ removeLink "tmp"
+            e <- tryIO $ createNamedPipe "tmp" 0
+            case e of
+                -- Creating named pipe might fail on some filesystems
+                Left _ -> return ()
+                Right _ -> do
+                    ft <- getFileType [osp|tmp|]
+                    _  <- tryIO $ removeLink "tmp"
+                    ft `shouldBe` FTOther
+        it "recursive symlink is other" $ do
+            _ <- tryIO $ removeLink "tmp"
+            createSymbolicLink "tmp" "tmp"
+            ft <- getFileType [osp|tmp|]
+            _  <- tryIO $ removeLink "tmp"
+            ft `shouldBe` FTOther
+        it "dangling symlink is other" $ do
+            _  <- tryIO $ removeLink "tmp"
+            createSymbolicLink "doesnotexist" "tmp"
+            ft <- getFileType [osp|tmp|]
+            _  <- tryIO $ removeLink "tmp"
+            ft `shouldBe` FTOther
+
+tryIO :: IO a -> IO (Either IOException a)
+tryIO = try
+#endif


### PR DESCRIPTION
The implementation was copied from `Data.Streaming.Filesystem` with slight modifications.