### PR TITLE
Allow Unix sockets on Windows

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for streaming-commons
 
+## 0.2.3.0
+
+* Allow Unix sockets on Windows (https://github.com/fpco/streaming-commons/pull/80)
+
 ## 0.2.2.6
 
 * Remove the zlib headers [#72](https://github.com/fpco/streaming-commons/issues/72)

--- a/Data/Streaming/Network/Internal.hs
+++ b/Data/Streaming/Network/Internal.hs
@@ -5,11 +5,9 @@ module Data.Streaming.Network.Internal
     , HostPreference (..)
     , Message (..)
     , AppData (..)
-#if !WINDOWS
     , ServerSettingsUnix (..)
     , ClientSettingsUnix (..)
     , AppDataUnix (..)
-#endif
     ) where
 
 import Data.String (IsString (..))
@@ -73,7 +71,6 @@ instance IsString HostPreference where
     fromString "!6" = HostIPv6Only
     fromString s = Host s
 
-#if !WINDOWS
 -- | Settings for a Unix domain sockets server.
 data ServerSettingsUnix = ServerSettingsUnix
     { serverPath :: !FilePath
@@ -92,7 +89,6 @@ data AppDataUnix = AppDataUnix
     { appReadUnix :: !(IO ByteString)
     , appWriteUnix :: !(ByteString -> IO ())
     }
-#endif
 
 -- | Representation of a single UDP message
 data Message = Message { msgData :: {-# UNPACK #-} !ByteString

--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -1,5 +1,5 @@
 name:                streaming-commons
-version:             0.2.2.6
+version:             0.2.3.0
 synopsis:            Common lower-level functions needed by various streaming data libraries
 description:         Provides low-dependency functionality commonly needed by various streaming data libraries, such as conduit and pipes.
 homepage:            https://github.com/fpco/streaming-commons


### PR DESCRIPTION
Windows has supported Unix sockets since since 2017; see [here](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/).

This builds for me on Windows 11. I was also able to get `conduit` to build against this, making the `Data.Conduit.Network.Unix` module available on Windows. Closes #77.