### PR TITLE
Allow text-2.1 (mirroring a Hackage revision)

### DIFF
--- a/streaming-commons.cabal
+++ b/streaming-commons.cabal
@@ -47,7 +47,7 @@ library
                      , random
                      , process
                      , stm
-                     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.1
+                     , text >= 1.2 && < 1.3 || >= 2.0 && < 2.2
                      , transformers
                      , zlib
 


### PR DESCRIPTION
Closes #76

This has already been applied on Hackage, see https://github.com/fpco/streaming-commons/issues/76#issuecomment-1758188444