### PR TITLE
Fix case of windows headers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix `!6` host preference incorrectly allows IPv4 connections (https://github.com/fpco/streaming-commons/pull/83)
+* Fix case of windows header files to allow cross-compilation from linux to windows (https://github.com/fpco/streaming-commons/pull/84)
 
 ## 0.2.3.0
 

--- a/System/Win32File.hsc
+++ b/System/Win32File.hsc
@@ -31,8 +31,8 @@ import Data.ByteString.Lazy.Internal (defaultChunkSize)
 
 
 #include <fcntl.h>
-#include <Share.h>
-#include <SYS/Stat.h>
+#include <share.h>
+#include <sys/stat.h>
 #include <errno.h>
 
 newtype OFlag = OFlag CInt


### PR DESCRIPTION
Seems to fix https://github.com/fpco/streaming-commons/issues/21 for case-sensitive file systems, e.g. cross-compiling from linux to windows